### PR TITLE
Add -Wextra to build flags

### DIFF
--- a/Arduino/Navigation/platformio.ini
+++ b/Arduino/Navigation/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:uno]
-build_flags = -Wall
+build_flags = -Wall -Wextra
 platform = atmelavr
 board = uno
 framework = arduino

--- a/Arduino/Propulsion/platformio.ini
+++ b/Arduino/Propulsion/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:uno]
-build_flags = -Wall
+build_flags = -Wall -Wextra
 platform = atmelavr
 board = uno
 framework = arduino

--- a/Arduino/Propulsion_LagTest/platformio.ini
+++ b/Arduino/Propulsion_LagTest/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:uno]
-build_flags = -Wall
+build_flags = -Wall -Wextra
 platform = atmelavr
 board = uno
 framework = arduino

--- a/Arduino/Propulsion_Test/platformio.ini
+++ b/Arduino/Propulsion_Test/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:uno]
-build_flags = -Wall
+build_flags = -Wall -Wextra
 platform = atmelavr
 board = uno
 framework = arduino

--- a/Arduino/Wireless_Boat/platformio.ini
+++ b/Arduino/Wireless_Boat/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:uno]
-build_flags = -Wall
+build_flags = -Wall -Wextra
 platform = atmelavr
 board = uno
 framework = arduino

--- a/Arduino/Wireless_Shore/platformio.ini
+++ b/Arduino/Wireless_Shore/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:uno]
-build_flags = -Wall
+build_flags = -Wall -Wextra
 platform = atmelavr
 board = uno
 framework = arduino


### PR DESCRIPTION
From [*Using the GNU Compiler Collection (GCC): Warning Options*][1]:

> **`-Wextra`**
> This enables some extra warning flags that are not enabled by `-Wall`. (This option used to be called `-W`. The older name is still supported, but the newer name is more descriptive.)
>
>     -Wclobbered
>     -Wempty-body
>     -Wignored-qualifiers
>     -Wimplicit-fallthrough=3
>     -Wmissing-field-initializers
>     -Wmissing-parameter-type (C only)
>     -Wold-style-declaration (C only)
>     -Woverride-init
>     -Wsign-compare (C only)
>     -Wtype-limits
>     -Wuninitialized
>     -Wshift-negative-value (in C++03 and in C99 and newer)
>     -Wunused-parameter (only with -Wunused or -Wall)
>     -Wunused-but-set-parameter (only with -Wunused or -Wall)
>
> The option -Wextra also prints warning messages for the following cases:
>
> - A pointer is compared against integer zero with `<`, `<=`, `>`, or `>=`.
> - (C++ only) An enumerator and a non-enumerator both appear in a conditional expression.
> - (C++ only) Ambiguous virtual bases.
> - (C++ only) Subscripting an array that has been declared `register`.
> - (C++ only) Taking the address of a variable that has been declared `register`.
> - (C++ only) A base class is not initialized in the copy constructor of a derived class.

  [1]:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wextra