### PR TITLE
Fix remaining lint errors in sketches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,4 @@ env:
 script:
     - cd $PROJECT
     - platformio run
-# Enable this once the errors have been resolved
-#     - cpplint --quiet --recursive .
+    - cpplint --quiet --recursive .

--- a/Arduino/Propulsion/src/PropulsionModule.cpp
+++ b/Arduino/Propulsion/src/PropulsionModule.cpp
@@ -61,7 +61,7 @@ void setup() {
 void loop() {
   if (Serial.available()) {
     Serial.readBytes(sRead, MAX_MSG_LENGTH);
-    if ((sRead[0] == (char) newMessage) && (sRead[1] >= 0x10) && (sRead[1] <= 0x1F)) {
+    if ((sRead[0] == static_cast<char>(newMessage)) && (sRead[1] >= 0x10) && (sRead[1] <= 0x1F)) {
       commandByte = sRead[1];  // the commandByte byte is byte 1 of the request
     }
     if (commandByte == RESET_CMD) {

--- a/Arduino/Propulsion/src/PropulsionModule.cpp
+++ b/Arduino/Propulsion/src/PropulsionModule.cpp
@@ -61,7 +61,11 @@ void setup() {
 void loop() {
   if (Serial.available()) {
     Serial.readBytes(sRead, MAX_MSG_LENGTH);
-    if ((sRead[0] == static_cast<char>(newMessage)) && (sRead[1] >= 0x10) && (sRead[1] <= 0x1F)) {
+    if (
+         (sRead[0] == static_cast<char>(newMessage))
+      && (sRead[1] >= 0x10)
+      && (sRead[1] <= 0x1F)
+    ) {
       commandByte = sRead[1];  // the commandByte byte is byte 1 of the request
     }
     if (commandByte == RESET_CMD) {
@@ -167,7 +171,12 @@ void SetSpeeds() {
   commandByte = 0;
   M0Speed = byteToInt(2);
   M1Speed = byteToInt(4);
-  if ((M0Speed > 127) || (M0Speed < -127) || (M1Speed > 127) || (M1Speed < -127)) {
+  if (
+       (M0Speed > 127)
+    || (M0Speed < -127)
+    || (M1Speed > 127)
+    || (M1Speed < -127)
+  ) {
     errorByte = 0x02;
     errorReply(errorByte);
     return;

--- a/Arduino/Wireless_Boat/src/Wireless_Boat.cpp
+++ b/Arduino/Wireless_Boat/src/Wireless_Boat.cpp
@@ -93,7 +93,11 @@ void loop() {
 
   if (Serial.available()) {
     Serial.readBytes(sRead, MAX_MSG_LENGTH);
-    if ((sRead[0] == static_cast<char>(newMessage)) && (sRead[1] >= 0x00) && (sRead[1] <= 0x0F)) {
+    if (
+         (sRead[0] == static_cast<char>(newMessage))
+      && (sRead[1] >= 0x00)
+      && (sRead[1] <= 0x0F)
+    ) {
       commandByte = sRead[1];  // the commandByte byte is byte 1 of the request
     }
     if (commandByte == RESET_CMD) {

--- a/Arduino/Wireless_Boat/src/Wireless_Boat.cpp
+++ b/Arduino/Wireless_Boat/src/Wireless_Boat.cpp
@@ -85,7 +85,7 @@ void loop() {
   // check if something was received (could be an interrupt from the radio)
   rxDone = radio.receiveDone();
   if (rxDone) {
-    memcpy(RXPayload, reinterpret_cast<void*>(radio.DATA), 61);
+    memcpy(RXPayload, reinterpret_cast<volatile void*>(radio.DATA), 61);
   }
   if (radio.ACKRequested()) {
     radio.sendACK();

--- a/Arduino/Wireless_Boat/src/Wireless_Boat.cpp
+++ b/Arduino/Wireless_Boat/src/Wireless_Boat.cpp
@@ -85,7 +85,7 @@ void loop() {
   // check if something was received (could be an interrupt from the radio)
   rxDone = radio.receiveDone();
   if (rxDone) {
-    memcpy(RXPayload, (void*)radio.DATA, 61);
+    memcpy(RXPayload, reinterpret_cast<void*>(radio.DATA), 61);
   }
   if (radio.ACKRequested()) {
     radio.sendACK();
@@ -93,7 +93,7 @@ void loop() {
 
   if (Serial.available()) {
     Serial.readBytes(sRead, MAX_MSG_LENGTH);
-    if ((sRead[0] == (char) newMessage) && (sRead[1] >= 0x00) && (sRead[1] <= 0x0F)) {
+    if ((sRead[0] == static_cast<char>(newMessage)) && (sRead[1] >= 0x00) && (sRead[1] <= 0x0F)) {
       commandByte = sRead[1];  // the commandByte byte is byte 1 of the request
     }
     if (commandByte == RESET_CMD) {

--- a/Arduino/Wireless_Shore/src/Wireless_Shore.cpp
+++ b/Arduino/Wireless_Shore/src/Wireless_Shore.cpp
@@ -93,7 +93,11 @@ void loop() {
 
   if (Serial.available()) {
     Serial.readBytes(sRead, MAX_MSG_LENGTH);
-    if ((sRead[0] == static_cast<char>(newMessage)) && (sRead[1] >= 0x00) && (sRead[1] <= 0x0F)) {
+    if (
+         (sRead[0] == static_cast<char>(newMessage))
+      && (sRead[1] >= 0x00)
+      && (sRead[1] <= 0x0F)
+    ) {
       commandByte = sRead[1];  // the commandByte byte is byte 1 of the request
     }
     if (commandByte == RESET_CMD) {

--- a/Arduino/Wireless_Shore/src/Wireless_Shore.cpp
+++ b/Arduino/Wireless_Shore/src/Wireless_Shore.cpp
@@ -85,7 +85,7 @@ void loop() {
   // check if something was received (could be an interrupt from the radio)
   rxDone = radio.receiveDone();
   if (rxDone) {
-    memcpy(RXPayload, reinterpret_cast<void*>(radio.DATA), 61);
+    memcpy(RXPayload, reinterpret_cast<volatile void*>(radio.DATA), 61);
   }
   if (radio.ACKRequested()) {
     radio.sendACK();

--- a/Arduino/Wireless_Shore/src/Wireless_Shore.cpp
+++ b/Arduino/Wireless_Shore/src/Wireless_Shore.cpp
@@ -85,7 +85,7 @@ void loop() {
   // check if something was received (could be an interrupt from the radio)
   rxDone = radio.receiveDone();
   if (rxDone) {
-    memcpy(RXPayload, (void*)radio.DATA, 61);
+    memcpy(RXPayload, reinterpret_cast<void*>(radio.DATA), 61);
   }
   if (radio.ACKRequested()) {
     radio.sendACK();
@@ -93,7 +93,7 @@ void loop() {
 
   if (Serial.available()) {
     Serial.readBytes(sRead, MAX_MSG_LENGTH);
-    if ((sRead[0] == (char) newMessage) && (sRead[1] >= 0x00) && (sRead[1] <= 0x0F)) {
+    if ((sRead[0] == static_cast<char>(newMessage)) && (sRead[1] >= 0x00) && (sRead[1] <= 0x0F)) {
       commandByte = sRead[1];  // the commandByte byte is byte 1 of the request
     }
     if (commandByte == RESET_CMD) {


### PR DESCRIPTION
Closes #18

This PR fixes the remaining lint errors in the projects. The remaining errors were:

```text
Arduino/Propulsion/src/PropulsionModule.cpp:64:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
Arduino/Propulsion/src/PropulsionModule.cpp:64:  Using C-style cast.  Use static_cast<char>(...) instead  [readability/casting] [4]
Arduino/Propulsion/src/PropulsionModule.cpp:170:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
Arduino/Wireless_Boat/src/Wireless_Boat.cpp:88:  Using C-style cast.  Use reinterpret_cast<void*>(...) instead  [readability/casting] [4]
Arduino/Wireless_Boat/src/Wireless_Boat.cpp:96:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
Arduino/Wireless_Boat/src/Wireless_Boat.cpp:96:  Using C-style cast.  Use static_cast<char>(...) instead  [readability/casting] [4]
Arduino/Wireless_Shore/src/Wireless_Shore.cpp:88:  Using C-style cast.  Use reinterpret_cast<void*>(...) instead  [readability/casting] [4]
Arduino/Wireless_Shore/src/Wireless_Shore.cpp:96:  Lines should be <= 80 characters long  [whitespace/line_length] [2]
Arduino/Wireless_Shore/src/Wireless_Shore.cpp:96:  Using C-style cast.  Use static_cast<char>(...) instead  [readability/casting] [4]
```

The errors can be grouped into two categories, and related back to the [Google C++ Style Guide][1], which describes the rules much better than I can:

- The `readability/casting` errors concern [the *Casting* section in the style guide][2]:

    > Use C++-style casts like `static_cast<float>(double_value)`, or brace initialization for conversion of arithmetic types like `int64 y = int64{1} << 42`. Do not use cast formats like `int y = (int)x` or `int y = int(x)` (but the latter is okay when invoking a constructor of a class type).
    > 
    > **Definition:**
    > C++ introduced a different cast system from C that distinguishes the types of cast operations.
    > 
    > **Pros:**
    > The problem with C casts is the ambiguity of the operation; sometimes you are doing a *conversion* (e.g., `(int)3.5`) and sometimes you are doing a *cast* (e.g., `(int)"hello"`). Brace initialization and C++ casts can often help avoid this ambiguity. Additionally, C++ casts are more visible when searching for them.
    > 
    > **Cons:**
    > The C++-style cast syntax is verbose and cumbersome.
    > 
    > **Decision:**
    > Do not use C-style casts. Instead, use these C++-style casts when explicit type conversion is necessary.
    > 
    > - Use brace initialization to convert arithmetic types (e.g. `int64{x}`). This is the safest approach because code will not compile if conversion can result in information loss. The syntax is also concise.
    > - Use `static_cast` as the equivalent of a C-style cast that does value conversion, when you need to explicitly up-cast a pointer from a class to its superclass, or when you need to explicitly cast a pointer from a superclass to a subclass. In this last case, you must be sure your object is actually an instance of the subclass.
    > - Use `const_cast` to remove the `const` qualifier ([...]).
    > - Use `reinterpret_cast` to do unsafe conversions of pointer types to and from integer and other pointer types. Use this only if you know what you are doing and you understand the aliasing issues.

- The `whitespace/line_length` concern [the *Line Length* section in the style guide][3]:

    > Each line of text in your code should be at most 80 characters long.
    > 
    > We recognize that this rule is controversial, but so much existing code already adheres to it, and we feel that consistency is important.
    > 
    > **Pros:**
    > Those who favor this rule argue that it is rude to force them to resize their windows and there is no need for anything longer. Some folks are used to having several code windows side-by-side, and thus don't have room to widen their windows in any case. People set up their work environment assuming a particular maximum window width, and 80 columns has been the traditional standard. Why change it?
    > 
    > **Cons:**
    > Proponents of change argue that a wider line can make code more readable. The 80-column limit is an hidebound throwback to 1960s mainframes; modern equipment has wide screens that can easily show longer lines.
    > 
    > **Decision:**
    > 80 characters is the maximum.
    > 
    > **Exception:**
    > Comment lines can be longer than 80 characters if it is not feasible to split them without harming readability, ease of cut and paste or auto-linking -- e.g. if a line contains an example command or a literal URL longer than 80 characters.
    > 
    > **Exception:**
    > A raw-string literal may have content that exceeds 80 characters. Except for test code, such literals should appear near the top of a file.
    > 
    > **Exception:**
    > An `#include` statement with a long path may exceed 80 columns.
    > 
    > **Exception:**
    > You needn't be concerned about header guards that exceed the maximum length.

The respective errors were fixed in a38c026 and 49f764a. With these fixes in place, cpplint now produces no errors and I've gone ahead and enabled it on Travis CI (95096fd) to allow us to keep these issues at bay.

  [1]:https://google.github.io/styleguide/cppguide.html
  [2]:http://google.github.io/styleguide/cppguide.html#Casting
  [3]:http://google.github.io/styleguide/cppguide.html#Line_Length
