### PR TITLE
Add -Wshadow to build_flags

### DIFF
--- a/Arduino/Navigation/platformio.ini
+++ b/Arduino/Navigation/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:uno]
-build_flags = -Wall -Wextra
+src_build_flags = -Wall -Wextra -Wshadow
 platform = atmelavr
 board = uno
 framework = arduino

--- a/Arduino/Propulsion/platformio.ini
+++ b/Arduino/Propulsion/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:uno]
-build_flags = -Wall -Wextra
+src_build_flags = -Wall -Wextra -Wshadow
 platform = atmelavr
 board = uno
 framework = arduino

--- a/Arduino/Wireless_Basic/platformio.ini
+++ b/Arduino/Wireless_Basic/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:uno]
-build_flags = -Wall -Wextra
+src_build_flags = -Wall -Wextra -Wshadow
 platform = atmelavr
 board = uno
 framework = arduino

--- a/Arduino/Wireless_Boat/platformio.ini
+++ b/Arduino/Wireless_Boat/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:uno]
-build_flags = -Wall -Wextra
+src_build_flags = -Wall -Wextra -Wshadow
 platform = atmelavr
 board = uno
 framework = arduino

--- a/Arduino/Wireless_Shore/platformio.ini
+++ b/Arduino/Wireless_Shore/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:uno]
-build_flags = -Wall -Wextra
+src_build_flags = -Wall -Wextra -Wshadow
 platform = atmelavr
 board = uno
 framework = arduino


### PR DESCRIPTION
This PR adds [`-Wshadow`][1] to the build flags for the projects.

From [*Using the GNU Compiler Collection (GCC): Warning Options*][1]:

> `-Wshadow`
> Warn whenever a local variable or type declaration shadows another variable, parameter, type, class member (in C++), or instance variable (in Objective-C) or whenever a built-in function is shadowed. Note that in C++, the compiler warns if a local variable shadows an explicit typedef, but not if it shadows a struct/class/enum. Same as `-Wshadow=global`.
>
> `-Wshadow=global`
> The default for `-Wshadow`. Warns for any (global) shadowing.
>
> `-Wshadow=local`
> Warn when a local variable shadows another local variable or parameter. This warning is enabled by `-Wshadow=global`.
>
> `-Wshadow=compatible-local`
> Warn when a local variable shadows another local variable or parameter whose type is compatible with that of the shadowing variable. In C++, type compatibility here means the type of the shadowing variable can be converted to that of the shadowed variable. The creation of this flag (in addition to `-Wshadow=local`) is based on the idea that when a local variable shadows another one of incompatible type, it is most likely intentional, not a bug or typo, as shown in the following example:
> 
>     for (SomeIterator i = SomeObj.begin(); i != SomeObj.end(); ++i)
>     {
>       for (int i = 0; i < N; ++i)
>       {
>         ...
>       }
>       ...
>     }
> Since the two variable `i` in the example above have incompatible types, enabling only `-Wshadow=compatible-local` will not emit a warning. Because their types are incompatible, if a programmer accidentally uses one in place of the other, type checking will catch that and emit an error or warning. So not warning (about shadowing) in this case will not lead to undetected bugs. Use of this flag instead of `-Wshadow=local` can possibly reduce the number of warnings triggered by intentional shadowing.
>
> This warning is enabled by `-Wshadow=local`.

  [1]:https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
