### PR TITLE
Add requirements file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@ cache:
     directories:
         - "~/.platformio"
 
-install:
-    - pip install -U cpplint platformio
-
 env:
     - PROJECT=Arduino/Navigation
     - PROJECT=Arduino/Propulsion

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+arrow==0.10.0
+bottle==0.12.13
+certifi==2017.7.27.1
+chardet==3.0.4
+click==5.1
+colorama==0.3.9
+cpplint==1.3.0
+idna==2.6
+lockfile==0.12.2
+platformio==3.4.1
+pyserial==3.4
+python-dateutil==2.6.1
+requests==2.18.4
+semantic-version==2.6.0
+six==1.10.0
+urllib3==1.22


### PR DESCRIPTION
This PR adds [a requirements file (`requirements.txt`)][1] to the project root.

From [the pip 1.1 documentation on requirements files][1]:

> When installing software, and Python packages in particular, it’s common that you get a lot of libraries installed. [...] Each of these packages has its own version. [...] So what are requirements files? They are very simple: lists of packages to install.

Instead of running `pip install -U cpplint platformio` on Travis CI (see #26 for more on Travis CI) we can now point to the `requirements.txt` file and have it install everything listed there—using the `requirements.txt` file forces particular versions of everything to install.

I've remove the explicit install step from Travis CI as the default behaviour for a Python project is to look for a `requirements.txt` file (see [*Building a Python Project*](https://docs.travis-ci.com/user/languages/python/)).

  [1]:https://pip.readthedocs.io/en/1.1/requirements.html