### PR TITLE
Add initial support for the Dual Motor TinyShield to the Propulsion Module

### DIFF
--- a/Arduino/Propulsion/platformio.ini
+++ b/Arduino/Propulsion/platformio.ini
@@ -16,3 +16,12 @@ framework = arduino
 lib_deps =
   PololuQik
   https://github.com/vinmenn/Crc16
+
+[env:tinyduino]
+src_build_flags = -DTINYDUINO -Wall -Wextra -Wshadow
+platform = atmelavr
+board = tinyduino
+framework = arduino
+lib_deps =
+  https://github.com/TinyCircuits/TinyCircuits-TinyShield_Motor_Library
+  https://github.com/vinmenn/Crc16

--- a/Arduino/Propulsion/src/PropulsionModule.cpp
+++ b/Arduino/Propulsion/src/PropulsionModule.cpp
@@ -1,11 +1,17 @@
 #include <Arduino.h>
+
 #ifdef TINYDUINO
+
 #include <Wire.h>
 #include <MotorDriver.h>
+
 #else
+
 #include <SoftwareSerial.h>  // specific to Propulsion Module
 #include <PololuQik.h>  // specific to Propulsion Module
+
 #endif
+
 #include <Crc16.h>
 
 #define RESET_CMD (byte) 0x10


### PR DESCRIPTION
This PR adds support for the [TinyCircuits Dual Motor TinyShield](https://tinycircuits.com/collections/all/products/dual-motor-tinyshield) by conditionally replacing usages of `PololuQik2s12v10` with the [TinyCircuits Motor Drvier Arduino library](https://github.com/TinyCircuits/TinyCircuits-TinyShield_Motor_Library)'s `MotorDriver`.

My thinking is that Dual Motor TinyShield is the special case here and that it should be the check performed (i.e. "if this is being built for a TinyDuino do *x*, otherwise the default is an Arduino" vs. "if this is being built for an Arduino do *x*, otherwise the default is a TinyDuino") and as such I've added `#ifdef`s for a `TINYDUINO` macro where needed.

One complication is that a lot of the functionality exposed by the Arduino library for the Pololu Qik isn't available with the TinyShield. I've proposed a new payload value for the Propulsion Module API's General Error Message ([`0x1F`][2]) to indicate that the given command isn't available—I'm very open to alternatives here, as I don't think this will stand the test of time (e.g. when we go to use these commands we'll need them to work equally across both boards).

  [2]:https://github.com/LakeMaps/microcontrollers/wiki/Propulsion-Microcontroller-API#command-0x1f--general-error-message

I've tested this with the hardware with the following script and it seems to work well:

```text
>>> import serial
>>> s = serial.Serial('/dev/cu.usbserial-DO00BW3D', baudrate=57600)
>>> s.write(bytearray([0xaa, 0x13, 0x00, 0x7f, 0x00, 0x00, 0x79, 0x9b]))
8
>>> hex(ord(s.read()))
'0xaa'
>>> hex(ord(s.read()))
'0x13'
>>> hex(ord(s.read()))
'0x0'
>>> hex(ord(s.read()))
'0x7f'
>>> hex(ord(s.read()))
'0x0'
>>> hex(ord(s.read()))
'0x0'
>>> hex(ord(s.read()))
'0x79'
>>> hex(ord(s.read()))
'0x9b'
>>> s.write(bytearray([0xaa, 0x13, 0x00, 0x7f, 0x00, 0x00, 0x79, 0x9b]))
8
```