### PR TITLE
Propulsion conversion to Nano

### DIFF
--- a/Arduino/Propulsion/platformio.ini
+++ b/Arduino/Propulsion/platformio.ini
@@ -8,10 +8,10 @@
 ; Please visit documentation for the other options and examples
 ; http://docs.platformio.org/page/projectconf.html
 
-[env:uno]
+[env:nanoatmega328]
 src_build_flags = -Wall -Wextra -Wshadow
 platform = atmelavr
-board = uno
+board = nanoatmega328
 framework = arduino
 lib_deps =
   PololuQik

--- a/Arduino/Propulsion/src/PropulsionModule.cpp
+++ b/Arduino/Propulsion/src/PropulsionModule.cpp
@@ -51,7 +51,7 @@ void initDriver() {
   m1->run(RELEASE);
 }
 #else
-PololuQik2s12v10 qik(12, 13, 11);  // RX, TX, RESET pins on motor driver
+PololuQik2s12v10 qik(2, 3, 4);  // RX, TX, RESET pins on motor driver
 void initDriver() {
   qik.init();
 }

--- a/Arduino/Propulsion/src/PropulsionModule.cpp
+++ b/Arduino/Propulsion/src/PropulsionModule.cpp
@@ -51,7 +51,7 @@ void initDriver() {
   m1->run(RELEASE);
 }
 #else
-PololuQik2s12v10 qik(2, 3, 4);  // RX, TX, RESET pins on motor driver
+PololuQik2s12v10 qik(3, 2, 4);  // TX, RX, RESET pins as written on motor driver
 void initDriver() {
   qik.init();
 }


### PR DESCRIPTION
Converts the propulsion microcontroller sketch to work with an arduino nano instead of an uno.
Tested on hardware 2017-12-03.